### PR TITLE
update composer versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Add mustache-l4 as a dependency to your `composer.json` file
 ```json
 "require": {
 	"laravel/framework": "4.0.*",
-	"conarwelsh/mustache-l4": "dev-master"
+	"conarwelsh/mustache-l4": "1.0.*"
 }
 ```
 	

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "conarwelsh/mustache-l4",
     "type": "library",
+    "version": "1.0.0",
     "description": "A Mustache.php wrapper for Laravel 4",
     "keywords": ["laravel", "laravel 4", "mustache", "php"],
     "homepage": "https://github.com/conarwelsh/mustache-l4",
@@ -14,12 +15,12 @@
     "require": {
         "php": ">=5.3.0",
         "illuminate/support": "~4",
-        "mustache/mustache": "dev-master"
+        "mustache/mustache": "2.6.*"
     },
     "autoload": {
         "psr-0": {
             "Conarwelsh\\MustacheL4": "src/"
         }
     },
-    "minimum-stability": "dev"
+    "minimum-stability": "stable"
 }


### PR DESCRIPTION
The current stability settings and lack of versions causes a conflict with Laravel's default minimum stability, this fixes it.